### PR TITLE
Fix to_fx_function

### DIFF
--- a/lib/fx/adapters/mysql/functions.rb
+++ b/lib/fx/adapters/mysql/functions.rb
@@ -40,7 +40,7 @@ module Fx
 
         def to_fx_function(result)
           name = result.fetch("name")
-          definition = "DELIMITER $$\n#{delete_definer(find_definition(name))}$$\nDELIMITER ;"
+          definition = delete_definer(find_definition(name))
           Fx::Function.new(
             "name" => name,
             "definition" => definition

--- a/spec/fx/adapters/mysql/functions_spec.rb
+++ b/spec/fx/adapters/mysql/functions_spec.rb
@@ -16,11 +16,9 @@ RSpec.describe Fx::Adapters::MySQL::Functions do
       expect(functions.size).to eq 1
       expect(first.name).to eq "test"
       expect(first.definition).to eq <<-SQL.strip_heredoc.chomp
-        DELIMITER $$
         CREATE FUNCTION `test`() RETURNS text CHARSET #{connection.charset}
             DETERMINISTIC
-        RETURN 'test'$$
-        DELIMITER ;
+        RETURN 'test'
       SQL
     end
   end


### PR DESCRIPTION
While using the MySQL adapter, loading the db/schema.rb (automatically generated by `rails db:migrate`) results in the following error.
```
Caused by:
Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'DELIMITER $$ (Mysql2::Error)
```
I suppose the `DELIMITER` command is unnecessary for ActiveRecord.
https://stackoverflow.com/questions/41138771/creating-mysql-function-from-rails-migration

Thank you @f-mer 